### PR TITLE
Fixes file extension in default watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -128,7 +128,7 @@ gulp.task('server', ['build'], function() {
 // Build the site, run the server, and watch for file changes
 gulp.task('default', ['build', 'server'], function() {
   gulp.watch(paths.assets, ['copy']);
-  gulp.watch(['./src/pages/**/*.hbs'], ['pages']);
+  gulp.watch(['./src/pages/**/*.html'], ['pages']);
   gulp.watch(['./src/assets/scss/**/*.scss'], ['sass']);
   gulp.watch(['./src/assets/js/**/*.scss'], ['javascript']);
   gulp.watch(['./src/assets/img/**/*'], ['images']);


### PR DESCRIPTION
Hello!

I stumbled across the foundation SSG after looking at the motion UI repo from the email that went out this morning and was very excited to start playing around with it!

I noticed that the file extension in the default watch task was for Handlebars files (`.hbs`). That was preventing the the `.html` files updating when changes where made to them. I updated the gulpfile and it seems to be working as expected now.

Not sure if that was left over from Assemble, or I could be totally missing something :) Anyway, thought I would try to help a little. Great work on the SSG!

Thanks,

-Levi
