### PR TITLE
Watch task no longer breaks on sass errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,8 @@ gulp.task('sass', function() {
       includePaths: paths.sass,
       outputStyle: (isProduction ? 'compressed' : 'nested'),
       errLogToConsole: true
-    }))
+    })
+      .on('error', $.sass.logError))
     .pipe($.autoprefixer({
       browsers: ['last 2 versions', 'ie >= 9']
     }))


### PR DESCRIPTION
As requested here: https://github.com/zurb/foundation-sites-6/issues/256#issuecomment-157127601
