### PR TITLE
Fix _settings.scss markdown syntax

### DIFF
--- a/src/styleguide/index.md
+++ b/src/styleguide/index.md
@@ -127,7 +127,7 @@ As you've probably noticed in the examples above, you have access to a small, me
 
 # Colors
 
-<p class="lead">Below you can find the different values we created that support the primary color variable you can change at any time in <code>_settings.scss</code></p>
+<p class="lead">Below you can find the different values we created that support the primary color variable you can change at any time in <code>\_settings.scss</code></p>
 
 ---
 


### PR DESCRIPTION
Added a forward slash `\` to escape `_settings.scss`.

Markdown things it's the beginning of a bold tag and it messes with the syntax highlighting.
