### PR TITLE
Updated JS PATHS file exclusion/inclusion

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,7 @@ var PATHS = {
     'bower_components/foundation-sites/js/foundation.tabs.js',
     'bower_components/foundation-sites/js/foundation.toggler.js',
     'bower_components/foundation-sites/js/foundation.tooltip.js',
-    'src/assets/js/!(app.js)**/*.js',
+    'src/assets/js/**/*.js',
     'src/assets/js/app.js'
   ]
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,7 @@ var PATHS = {
     'bower_components/foundation-sites/js/foundation.tabs.js',
     'bower_components/foundation-sites/js/foundation.toggler.js',
     'bower_components/foundation-sites/js/foundation.tooltip.js',
-    'src/assets/js/**/*.js',
+    'src/assets/js/!(app.js)**/*.js',
     'src/assets/js/app.js'
   ]
 };


### PR DESCRIPTION
I noticed that the _app.js_ file was getting concatenated along with all of the other files/sub-directories that are added to the _/src/assets/js/_ directory. And since the file starts with an "a", it will often times get loaded before the other files that may be present as it concats alphabetically. 

I've updated one line in the gulpfile.js to skip the _app.js_ file when concatenating the additional libraries, files & subdirectories, then pull in the _app.js_ file last.

```
-    'src/assets/js/**/*.js',
+    'src/assets/js/!(app.js)**/*.js',
```
