### PR TITLE
Compressed css in output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,7 +111,8 @@ gulp.task('sass', function() {
   return gulp.src('src/assets/scss/app.scss')
     .pipe($.sourcemaps.init())
     .pipe($.sass({
-      includePaths: PATHS.sass
+      includePaths: PATHS.sass,
+      outputStyle: 'compressed'
     })
       .on('error', $.sass.logError))
     .pipe($.autoprefixer({


### PR DESCRIPTION
Compressed css after saving scss

Or an ability to change in the YetiLaunch in what format the style should be in output.
