### PR TITLE
Fix pattern excluding img from copy target

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var COMPATIBILITY = ['last 2 versions', 'ie >= 9'];
 var PATHS = {
   assets: [
     'src/assets/**/*',
-    '!src/assets/{!img,js,scss}/**/*'
+    '!src/assets/{img,js,scss}/**/*'
   ],
   sass: [
     'bower_components/foundation-sites/scss',


### PR DESCRIPTION
Test to reproduce bug:

```
touch src/assets/img/foo.bar
gulp clean
gulp copy
ls dist/assets/img
```

You will see that the file gets copied even though it should not. Whether the final version is the minified one or the unminified one depends on chance and how slow minification is.
