### PR TITLE
Give better indication about when tasks are done

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,13 +65,13 @@ gulp.task('clean', function(done) {
 // Copy files out of the assets folder
 // This task skips over the "img", "js", and "scss" folders, which are parsed separately
 gulp.task('copy', function() {
-  gulp.src(PATHS.assets)
+  return gulp.src(PATHS.assets)
     .pipe(gulp.dest('dist/assets'));
 });
 
 // Copy page templates into finished HTML files
 gulp.task('pages', function() {
-  gulp.src('src/pages/**/*.{html,hbs,handlebars}')
+  return gulp.src('src/pages/**/*.{html,hbs,handlebars}')
     .pipe(panini({
       root: 'src/pages/',
       layouts: 'src/layouts/',
@@ -84,8 +84,7 @@ gulp.task('pages', function() {
 
 gulp.task('pages:reset', function(cb) {
   panini.refresh();
-  gulp.run('pages');
-  cb();
+  gulp.run('pages', cb);
 });
 
 gulp.task('styleguide', function(cb) {


### PR DESCRIPTION
There are several places where the build script triggers some asynchroneous operation but makes no effort to inform gulp about this fact. This should make things better.

The `gulp.run` call is particularly broken. While running `npm run` in one console, touch the `src/layouts/default.html` from somewhere else. You will notice log output like this:

```
[…] Starting 'pages:reset'...
gulp.run() has been deprecated. Use task dependencies or gulp.watch task triggering instead.
[…] Starting 'pages'...
[…] Finished 'pages' after 9.58 ms
```

Note that there is _no_ mention of `Finished 'pages:reset'`, nor a line stating `[BS] Reloading Browsers`.
