### PR TITLE
fixes BrowserSync reload issue

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -126,10 +126,10 @@ function server(done) {
 // Watch for changes to static assets, pages, Sass, and JavaScript
 function watch() {
   gulp.watch(PATHS.assets, copy);
-  gulp.watch('src/pages/**/*.html', gulp.series(pages, browser.reload));
-  gulp.watch('src/{layouts,partials}/**/*.html', gulp.series(resetPages, pages, browser.reload));
+  gulp.watch('src/pages/**/*.html').on('change', gulp.series(pages, browser.reload));
+  gulp.watch('src/{layouts,partials}/**/*.html').on('change', gulp.series(resetPages, pages, browser.reload));
   gulp.watch('src/assets/scss/**/*.scss', sass);
-  gulp.watch('src/assets/js/**/*.js', gulp.series(javascript, browser.reload));
-  gulp.watch('src/assets/img/**/*', gulp.series(images, browser.reload));
-  gulp.watch('src/styleguide/**', gulp.series(styleGuide, browser.reload));
+  gulp.watch('src/assets/js/**/*.js').on('change', gulp.series(javascript, browser.reload));
+  gulp.watch('src/assets/img/**/*').on('change', gulp.series(images, browser.reload));
+  gulp.watch('src/styleguide/**').on('change', gulp.series(styleGuide, browser.reload));
 }


### PR DESCRIPTION
BrowserSync stops reloading in `gulp-cli@0.4.0` 
- updated watch task with `.on('change')`
