### PR TITLE
use an async function for reload to fix watch stall

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -123,13 +123,19 @@ function server(done) {
   done();
 }
 
+// Reload the browser with BrowserSync
+function reload(done) {
+  browser.reload();
+  done();
+}
+
 // Watch for changes to static assets, pages, Sass, and JavaScript
 function watch() {
   gulp.watch(PATHS.assets, copy);
-  gulp.watch('src/pages/**/*.html', gulp.series(pages, browser.reload));
-  gulp.watch('src/{layouts,partials}/**/*.html', gulp.series(resetPages, pages, browser.reload));
+  gulp.watch('src/pages/**/*.html', gulp.series(pages, reload));
+  gulp.watch('src/{layouts,partials}/**/*.html', gulp.series(resetPages, pages, reload));
   gulp.watch('src/assets/scss/**/*.scss', sass);
-  gulp.watch('src/assets/js/**/*.js', gulp.series(javascript, browser.reload));
-  gulp.watch('src/assets/img/**/*', gulp.series(images, browser.reload));
-  gulp.watch('src/styleguide/**', gulp.series(styleGuide, browser.reload));
+  gulp.watch('src/assets/js/**/*.js', gulp.series(javascript, reload));
+  gulp.watch('src/assets/img/**/*', gulp.series(images, reload));
+  gulp.watch('src/styleguide/**', gulp.series(styleGuide, reload));
 }


### PR DESCRIPTION
The `browser.reload` function should not be used directly as a task because it is not an async function.  The only reason this was working is due to an inconsistency in the gulp 4 API, but we've since corrected that behavior and it was causing the watch to stall.  This change makes the `reload` function async and also removes the annoying `<anonymous>` task name.
