### PR TITLE
Custom npm build script argument environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "gulpfile.js",
   "scripts": {
     "start": "gulp",
-    "build": "gulp build --production"
+    "build": "gulp build"
   },
   "author": "ZURB <foundation@zurb.com>",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -62,4 +62,4 @@ Finally, run `npm start` to run Gulp. Your finished site will be created in a fo
 http://localhost:8000
 ```
 
-To create compressed, production-ready assets, run `npm run build`.
+To create compressed, production-ready assets, run `npm run build -- --production`.


### PR DESCRIPTION
Allows passing a npm argument instead of forcing production. I thought this may be useful for development environments.

As of npm@2.0.0, you can use custom arguments when executing scripts. The special option -- is used by getopt to delimit the end of the options. npm will pass all the arguments after the -- directly to your script.
