### PR TITLE
Load gulp-cli from npmjs.com.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp": "gulpjs/gulp#4.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-babel": "^6.1.2",
-    "gulp-cli": "gulpjs/gulp-cli#4.0",
+    "gulp-cli": "^1.2.1",
     "gulp-concat": "^2.5.2",
     "gulp-cssnano": "^2.1.0",
     "gulp-extname": "^0.2.0",


### PR DESCRIPTION
The 4.0 branch of gulp/gulp-cli does not exist in the github repo anymore. With this patch, version 1.2.1 of gulp-cli is downloaded from npmjs.com
