### PR TITLE
Update gulpfile.babel.js

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -75,7 +75,7 @@ function styleGuide(done) {
 // Compile Sass into CSS
 // In production, the CSS is compressed
 function sass() {
-  return gulp.src('src/assets/scss/app.scss')
+  return gulp.src('src/assets/scss/*.scss')
     .pipe($.sourcemaps.init())
     .pipe($.sass({
       includePaths: PATHS.sass


### PR DESCRIPTION
remove the static name so it's much more flexible.

I can have template like this:

**my-template.html**
```
<html>
<link rel="stylesheet" type="text/css" href="{{root}}css/app2.css">
[...]
</html>
```

**app2.scss**
```
@import 'settings2';
@import 'foundation-emails';
@import 'template/template';
```

**_settings2.scss**
```
$primary-color: yellow;
[...]
```