### PR TITLE
remove browser.reload from sass watch

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -135,7 +135,7 @@ function watch() {
   gulp.watch(PATHS.assets, copy);
   gulp.watch('src/pages/**/*.html').on('all', gulp.series(pages, browser.reload));
   gulp.watch('src/{layouts,partials}/**/*.html').on('all', gulp.series(resetPages, pages, browser.reload));
-  gulp.watch('src/assets/scss/**/*.scss').on('all', gulp.series(sass, browser.reload));
+  gulp.watch('src/assets/scss/**/*.scss').on('all', sass);
   gulp.watch('src/assets/js/**/*.js').on('all', gulp.series(javascript, browser.reload));
   gulp.watch('src/assets/img/**/*').on('all', gulp.series(images, browser.reload));
   gulp.watch('src/styleguide/**').on('all', gulp.series(styleGuide, browser.reload));


### PR DESCRIPTION
Changes to stylesheets are streamed. See line 92:

```
    .pipe(browser.reload({ stream: true }));
```

So, fully reloading the browser is unnecessary. This PR simply runs the `sass` task with no serial `browser.reload`.