### PR TITLE
Bugfix for empty scss folder:

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -22,7 +22,7 @@ PATHS:
   # Paths to static assets that aren't images, CSS, or JavaScript
   assets:
     - "src/assets/**/*"
-    - "!src/assets/{img,js,scss}/**/*"
+    - "!src/assets/{img,js,scss}{,/**/*}"
   # Paths to Sass libraries, which can then be loaded with @import
   sass:
     - "bower_components/foundation-sites/scss"


### PR DESCRIPTION
This might be a bug in node, gulp or somewhere else. I changed one line
to make it work, this way, the folder itself and subfolders and files
are excluded properly.