### PR TITLE
TASK: add watcher for data and helpers in gulpfile

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -135,6 +135,8 @@ function watch() {
   gulp.watch(PATHS.assets, copy);
   gulp.watch('src/pages/**/*.html').on('all', gulp.series(pages, browser.reload));
   gulp.watch('src/{layouts,partials}/**/*.html').on('all', gulp.series(resetPages, pages, browser.reload));
+  gulp.watch('src/data/**/*.{js,json,yml}').on('all', gulp.series(resetPages, pages, browser.reload));
+  gulp.watch('src/helpers/**/*.js').on('all', gulp.series(resetPages, pages, browser.reload));
   gulp.watch('src/assets/scss/**/*.scss').on('all', sass);
   gulp.watch('src/assets/js/**/*.js').on('all', gulp.series(javascript, browser.reload));
   gulp.watch('src/assets/img/**/*').on('all', gulp.series(images, browser.reload));


### PR DESCRIPTION
This makes shure that the data and helpers are automatically updated if a file is changed. Currently this is only possible if a restart from gulp is triggered.

This is basically the same as #59 does, but adds also support to watch the helpers and get these updated.

Does fix https://github.com/zurb/panini/issues/123 and https://github.com/zurb/panini/issues/122.
