### PR TITLE
Consolidate Webpack config options into a single variable

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -96,16 +96,18 @@ function sass() {
 }
 
 let webpackConfig = {
-  rules: [
-    {
-      test: /.js$/,
-      use: [
-        {
-          loader: 'babel-loader'
-        }
-      ]
-    }
-  ]
+  module: {
+    rules: [
+      {
+        test: /.js$/,
+        use: [
+          {
+            loader: 'babel-loader'
+          }
+        ]
+      }
+    ]
+  }
 }
 // Combine JavaScript into one file
 // In production, the file is minified
@@ -113,7 +115,7 @@ function javascript() {
   return gulp.src(PATHS.entries)
     .pipe(named())
     .pipe($.sourcemaps.init())
-    .pipe(webpackStream({module: webpackConfig}, webpack2))
+    .pipe(webpackStream(webpackConfig, webpack2))
     .pipe($.if(PRODUCTION, $.uglify()
       .on('error', e => { console.log(e); })
     ))


### PR DESCRIPTION
I've Updated the call to [`webpackStream()`](https://github.com/zurb/foundation-zurb-template/blob/master/gulpfile.babel.js#L116) in the javascript task. 

The object being passed as the first argument has been replaced simply with the variable `webpackConfig`. Having been [previously initialized](https://github.com/zurb/foundation-zurb-template/blob/master/gulpfile.babel.js#L98-L109), this variable as been updated to include the properties that were removed from the aforementioned argument.

The goal is to consolidate the configuration into a single location so that expanding on it with additional properties can be accomplished more easily.

Pull request per @kball in [related issue](https://github.com/zurb/foundation-sites/issues/10424) opened on the official [foundation-sites](https://github.com/zurb/foundation-sites) repo.