### PR TITLE
fix: revert to gulp@4.0.0-alpha.2 #10816

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.7.2",
     "browser-sync": "^2.10.0",
-    "gulp": "gulpjs/gulp#4.0",
+    "gulp": "github:gulpjs/gulp#6d71a65",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-babel": "^6.1.2",
     "gulp-clean-css": "^3.3.1",


### PR DESCRIPTION
Gulp updated their vinyl version to v3, and this break some gulp plugins.

Closes https://github.com/zurb/foundation-sites/issues/10816
See: https://github.com/gulpjs/gulp/issues/2065