### PR TITLE
fix: revert to #10816 now gulp#4.0 is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.7.2",
     "browser-sync": "^2.10.0",
-    "gulp": "github:gulpjs/gulp#6d71a65",
+    "gulp": "github:gulpjs/gulp#4.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-babel": "^6.1.2",
     "gulp-clean-css": "^3.3.1",


### PR DESCRIPTION
See:
* https://github.com/zurb/foundation-zurb-template/pull/76#issuecomment-354474425
* https://github.com/gulpjs/gulp/issues/2065#issuecomment-354342793

`vinyl-fs` has been updated with a fix, and gulp#4.0 now use this new version.

Thank you @phated 