### PR TITLE
chore: bump gulp-sass to 3.1.0 for Node 8+ compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^2.2.1",
     "gulp-load-plugins": "^1.1.0",
-    "gulp-sass": "^2.1.0",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.2.0",
     "gulp-uncss": "^1.0.1",


### PR DESCRIPTION
Related Issue: https://github.com/zurb/foundation-sites/issues/10863