### PR TITLE
chore: update styleguide to XY grid and improve TOC

### DIFF
--- a/src/styleguide/index.md
+++ b/src/styleguide/index.md
@@ -22,41 +22,41 @@ Using this framework is easy. Here's how your code will look when you use a seri
 
 ```html
 <div class="grid-x">
-  <div class="small-6 medium-4 large-3 cell">...</div>
-  <div class="small-6 medium-8 large-9 cell">...</div>
+  <div class="cell small-6 medium-4 large-3">...</div>
+  <div class="cell small-6 medium-8 large-9">...</div>
 </div>
 ```
 
 <div class="grid-x display">
-  <div class="small-12 large-4 cell">4</div>
-  <div class="small-12 large-4 cell">4</div>
-  <div class="small-12 large-4 cell">4</div>
+  <div class="cell small-12 large-4">4</div>
+  <div class="cell small-12 large-4">4</div>
+  <div class="cell small-12 large-4">4</div>
 </div>
 <div class="grid-x display">
-  <div class="small-12 large-3 cell">3</div>
-  <div class="small-12 large-6 cell">6</div>
-  <div class="small-12 large-3 cell">3</div>
+  <div class="cell small-12 large-3">3</div>
+  <div class="cell small-12 large-6">6</div>
+  <div class="cell small-12 large-3">3</div>
 </div>
 <div class="grid-x display">
-  <div class="small-12 large-2 cell">2</div>
-  <div class="small-12 large-8 cell">8</div>
-  <div class="small-12 large-2 cell">2</div>
+  <div class="cell small-12 large-2">2</div>
+  <div class="cell small-12 large-8">8</div>
+  <div class="cell small-12 large-2">2</div>
 </div>
 <div class="grid-x display">
-  <div class="small-12 large-3 cell">3</div>
-  <div class="small-12 large-9 cell">9</div>
+  <div class="cell small-12 large-3">3</div>
+  <div class="cell small-12 large-9">9</div>
 </div>
 <div class="grid-x display">
-  <div class="small-12 large-4 cell">4</div>
-  <div class="small-12 large-8 cell">8</div>
+  <div class="cell small-12 large-4">4</div>
+  <div class="cell small-12 large-8">8</div>
 </div>
 <div class="grid-x display">
-  <div class="small-12 large-5 cell">5</div>
-  <div class="small-12 large-7 cell">7</div>
+  <div class="cell small-12 large-5">5</div>
+  <div class="cell small-12 large-7">7</div>
 </div>
 <div class="grid-x display">
-  <div class="small-12 large-6 cell">6</div>
-  <div class="small-12 large-6 cell">6</div>
+  <div class="cell small-12 large-6">6</div>
+  <div class="cell small-12 large-6">6</div>
 </div>
 
 ---
@@ -67,34 +67,34 @@ In the Grid you can nest cells down as far as you'd like. Just embed grid-x insi
 
 ```html
 <div class="grid-x">
-  <div class="small-8 cell">8
+  <div class="cell small-8">8
     <div class="grid-x">
-      <div class="small-8 cell">8 Nested
+      <div class="cell small-8">8 Nested
         <div class="grid-x">
-          <div class="small-8 cell">8 Nested Again</div>
-          <div class="small-4 cell">4</div>
+          <div class="cell small-8">8 Nested Again</div>
+          <div class="cell small-4">4</div>
         </div>
       </div>
-      <div class="small-4 cell">4</div>
+      <div class="cell small-4">4</div>
     </div>
   </div>
-  <div class="small-4 cell">4</div>
+  <div class="cell small-4">4</div>
 </div>
 ```
 
 <div class="grid-x display">
-  <div class="small-8 cell">8
+  <div class="cell small-8">8
     <div class="grid-x">
-      <div class="small-8 cell">8 Nested
+      <div class="cell small-8">8 Nested
         <div class="grid-x">
-          <div class="small-8 cell">8 Nested Again</div>
-          <div class="small-4 cell">4</div>
+          <div class="cell small-8">8 Nested Again</div>
+          <div class="cell small-4">4</div>
         </div>
       </div>
-      <div class="small-4 cell">4</div>
+      <div class="cell small-4">4</div>
     </div>
   </div>
-  <div class="small-4 cellgi">4</div>
+  <div class="cell small-4">4</div>
 </div>
 
 ---
@@ -105,22 +105,22 @@ As you've probably noticed in the examples above, you have access to a small, me
 
 ```html
 <div class="grid-x">
-  <div class="small-2 cell">2</div>
-  <div class="small-10 cell">10, last</div>
+  <div class="cell small-2">2</div>
+  <div class="cell small-10">10, last</div>
 </div>
 <div class="grid-x">
-  <div class="small-3 cell">3</div>
-  <div class="small-9 cell">9, last</div>
+  <div class="cell small-3">3</div>
+  <div class="cell small-9">9, last</div>
 </div>
 ```
 
 <div class="grid-x display">
-  <div class="small-2 cell">2</div>
-  <div class="small-10 cell">10, last</div>
+  <div class="cell small-2">2</div>
+  <div class="cell small-10">10, last</div>
 </div>
 <div class="grid-x display">
-  <div class="small-3 cell">3</div>
-  <div class="small-9 cell">9, last</div>
+  <div class="cell small-3">3</div>
+  <div class="cell small-9">9, last</div>
 </div>
 
 
@@ -131,32 +131,32 @@ As you've probably noticed in the examples above, you have access to a small, me
 
 ---
 
-<div class="row up-1 medium-up-3 large-up-5">
-  <div class="column">
+<div class="grid-x up-1 medium-up-3 large-up-5">
+  <div class="cell">
     <div class="color-block">
       <span style="background: #2199e8"></span>
       #2199e8
     </div>
   </div>
-  <div class="column">
+  <div class="cell">
     <div class="color-block">
       <span style="background: #3adb76"></span>
       #3adb76
     </div>
   </div>
-  <div class="column">
+  <div class="cell">
     <div class="color-block">
       <span style="background: #ffae00"></span>
       #ffae00
     </div>
   </div>
-  <div class="column">
+  <div class="cell">
     <div class="color-block">
       <span style="background: #ec5840"></span>
       #ec5840
     </div>
   </div>
-  <div class="column">
+  <div class="cell">
     <div class="color-block">
       <span style="background: #0a0a0a"></span>
       #0a0a0a
@@ -290,51 +290,51 @@ Form elements in Foundation are styled based on their type attribute rather than
 
 ```html_example
 <form>
-  <div class="row">
-    <div class="large-12 columns">
+  <div class="grid-x">
+    <div class="cell large-12">
       <label>Label</label>
       <input type="text" placeholder="placeholder">
     </div>
   </div>
-  <div class="row">
-    <div class="large-6 columns">
+  <div class="grid-x grid-margin-x">
+    <div class="cell large-6">
       <label>Label</label>
       <input type="text" placeholder="placeholder">
     </div>
-    <div class="large-6 columns">
-      <div class="row collapse">
+    <div class="cell large-6">
+
         <label>Label</label>
         <div class="input-group">
           <input class="input-group-field" type="text" placeholder="placeholder">
           <span class="input-group-label">.com</span>
         </div>
-      </div>
+
     </div>
   </div>
-  <div class="row">
-    <div class="large-12 columns">
+  <div class="grid-x">
+    <div class="cell large-12">
       <label>Select Box</label>
       <select>
-        <option value="good">Good</option>
+        <option value="good">Go od</option>
         <option value="better">Better</option>
         <option value="best">Best</option>
       </select>
     </div>
   </div>
-  <div class="row">
-    <div class="large-6 columns">
+  <div class="grid-x">
+    <div class="cell large-6">
       <label>Choose Your Favorite</label>
       <input type="radio" name="radio1" value="radio1" id="radio1"><label for="radio1">Red</label>
       <input type="radio" name="radio2" value="radio2" id="radio2"><label for="radio2">Blue</label>
     </div>
-    <div class="large-6 columns">
+    <div class="cell large-6">
       <label>Check these out</label>
       <input id="checkbox1" type="checkbox"><label for="checkbox1">Checkbox 1</label>
       <input id="checkbox2" type="checkbox"><label for="checkbox2">Checkbox 2</label>
     </div>
   </div>
-  <div class="row">
-    <div class="large-12 columns">
+  <div class="grid-x">
+    <div class="cell large-12">
       <label>Textarea Label</label>
       <textarea placeholder="placeholder"></textarea>
     </div>

--- a/src/styleguide/template.html
+++ b/src/styleguide/template.html
@@ -9,45 +9,58 @@
 
     <!-- Style guide-specific CSS goes here. -->
     <style>
-    /* This styles individual sections of the style guide */
-    .ss-section:not(:last-child) {
-      padding-bottom: 4rem;
-      border-bottom: 2px solid #ccc;
-      margin-bottom: 4rem;
-    }
+      /* This styles the sticky table of contents menu */
+      .table-of-contents .is-active {
+        background: #2199e8;
+        color: #fefefe;
+      }
+      /* This styles individual sections of the style guide */
+      .ss-section:not(:last-child) {
+        padding-bottom: 4rem;
+        border-bottom: 2px solid #ccc;
+        margin-bottom: 4rem;
+      }
 
-    /* This styles code blocks used for examples. */
-    .ss-code code {
-      display: block;
-      padding: 1rem;
-      overflow-x: scroll;
-      margin-bottom: 1.5rem;
-    }
+      /* This styles code blocks used for examples. */
+      .ss-code code {
+        display: block;
+        padding: 1rem;
+        overflow-x: scroll;
+        margin-bottom: 1.5rem;
+      }
 
-    /* This styles the example rows used in the grid documentation. */
-    .row.display {
-      background: #eee;
-      font-size: 11px;
-      margin-bottom: 10px;
-      line-height: 2rem;
-      border: solid 1px #c6c6c6;
-      margin-left: 0 !important;
-      margin-right: 0 !important; }
-      .row.display .columns:nth-child(2), .row.display .columns.small-centered, .row.display .columns.large-centered {
-        background: #e1e1e1; }
-      .row.display .columns.color-end {
-        background: #d4d4d4; }
+      /* This styles the example rows used in the grid documentation. */
+      .grid-x.display {
+        background: #eee;
+        font-size: 11px;
+        margin-bottom: 10px;
+        line-height: 2rem;
+        border: solid 1px #c6c6c6;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+      }
+      
+      .grid-x.display .cell:nth-child(2),
+      .grid-x.display .cell.small-centered,
+      .grid-x.display .cell.large-centered {
+        background: #e1e1e1;
+      }
 
-    /* This styles the color blocks used in the color documentation. */
-    .color-block {
-      border-radius: 2px;
-      display: block;
-      padding: 8px 8px 6px;
-      color: #333;
-      text-transform: uppercase;
-      border: 1px solid #ddd;
-      box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
-    }
+      .grid-x.display .cell.color-end {
+        background: #d4d4d4;
+      }
+
+      /* This styles the color blocks used in the color documentation. */
+      .color-block {
+        border-radius: 2px;
+        display: block;
+        padding: 8px 8px 6px;
+        color: #333;
+        text-transform: uppercase;
+        border: 1px solid #ddd;
+        box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+      }
+      
       .color-block span {
         display: block;
         width: 100%;
@@ -58,33 +71,37 @@
   </head>
   <body>
 
-    <div class="column row">
-      <h1>Client Style Guide</h1>
-      <p class="lead">This style guide was built with Foundation for Sites. For more information on how to use this responsive front-end framework, check out the documentation, get help from the Foundation community, or request immediate technical support.</p>
-      <a href="http://foundation.zurb.com/docs/" class="button">Visit the Docs</a>
-      <a href="http://foundation.zurb.com/forum/" class="secondary button">Foundation Forum</a>
-      <a href="http://foundation.zurb.com/business/business-support.html" class="secondary button">Technical Support</a>
-    </div>
+    <div class="grid-container">
+      <div class="grid-x grid-margin-x">
+        <div class="cell">
+          <h1>Client Style Guide</h1>
+          <p class="lead">This style guide was built with Foundation for Sites. For more information on how to use this responsive front-end framework, check out the documentation, get help from the Foundation community, or request immediate technical support.</p>
+          <a href="http://foundation.zurb.com/docs/" class="button">Visit the Docs</a>
+          <a href="http://foundation.zurb.com/forum/" class="secondary button">Foundation Forum</a>
+          <a href="http://foundation.zurb.com/business/business-support.html" class="secondary button">Technical Support</a>
+        </div>
+      </div>
 
-    <div class="column row"><div class="row collapse">
+      <div class="grid-x grid-margin-x" id="styleguide">
+        <div class="cell large-3 medium-4" data-sticky-container>
+          <div class="table-of-contents" data-sticky data-top-anchor="styleguide:top">
+            <ul class="vertical menu" data-magellan>
+              {{#each pages}}
+                <li><a href="#{{ anchor }}">{{ title }}</a></li>
+              {{/each}}
+            </ul>
+          </div>
+        </div>
 
-      <div class="large-3 medium-4 columns" data-sticky-container>
-        <ul class="vertical menu">
+        <div class="cell large-9 medium-8">
           {{#each pages}}
-            <li><a href="#{{ anchor }}">{{ title }}</a></li>
+            <section class="ss-section" id="{{ anchor }}" data-magellan-target="{{ anchor }}">
+              {{ body }}
+            </section>
           {{/each}}
-        </ul>
+        </div>  
       </div>
-
-      <div class="large-9 medium-8 columns">
-        {{#each pages}}
-          <section class="ss-section" id="{{ anchor }}">
-            {{ body }}
-          </section>
-        {{/each}}
-      </div>
-
-    </div></div>
+    </div>
 
     <script src="assets/js/app.js"></script>
   </body>


### PR DESCRIPTION
While working on https://github.com/zurb/foundation-sites/pull/11034 I found the styleguide was still using the float grid while the template is using the XY grid so it was not displaying properly.

This PR:
- Updates the styleguide to the XY grid syntax
- Cleans up CSS formatting in the `<head>` of the styleguide template
- Adds missing `data-sticky` attributes to table of contents menu (`data-sticky-container` was the only present before)
- Adds magellan and styling to the table of contents menu

If this PR is ok, I will also update:
- https://github.com/zurb/style-sherpa/blob/master/template.hbs
- https://github.com/zurb/foundation-sites/blob/develop/docs/pages/style-sherpa.md