### PR TITLE
Fix: call `done()` properly in `server` function

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -137,8 +137,7 @@ function images() {
 function server(done) {
   browser.init({
     server: PATHS.dist, port: PORT
-  });
-  done();
+  }, done);
 }
 
 // Reload the browser with BrowserSync


### PR DESCRIPTION
**Regards `server` function:**

Browsersync `.init` function accepts a callback as its second argument ([docs](https://browsersync.io/docs/api#api-init)).

This way, `done()` is being called properly: after Browsersync has completed all setup tasks.

**Before:**
`server` task starts and finishes immediately:

![done-before](https://user-images.githubusercontent.com/31923722/45438076-79e2a600-b6b6-11e8-8e24-3d4d903543c3.png)

**After:**
`server` task finishes where it should have:

![done-after](https://user-images.githubusercontent.com/31923722/45438090-8666fe80-b6b6-11e8-8c75-ce92f20be4f4.png)