### PR TITLE
fix: import Foundation with require to ensure it to be imported #111

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -1,9 +1,14 @@
 import $ from 'jquery';
-import whatInput from 'what-input';
+import 'what-input';
 
-window.$ = $;
+// Foundation JS relies on a global varaible. In ES6, all imports are hoisted
+// to the top of the file so if we used`import` to import Foundation,
+// it would execute earlier than we have assigned the global variable.
+// This is why we have to use CommonJS require() here since it doesn't
+// have the hoisting behavior.
+window.jQuery = $;
+require('foundation-sites');
 
-import Foundation from 'foundation-sites';
 // If you want to pick and choose which modules to include, comment out the above and uncomment
 // the line below
 //import './lib/foundation-explicit-pieces';


### PR DESCRIPTION
Import Foundation in the CommonJs way to ensure that it will be imported without tree-shaking, as we are relying on side-effects here.

Related to https://github.com/zurb/foundation-sites/issues/11586
Closes https://github.com/zurb/foundation-cli/issues/111