### PR TITLE
jpegtran replaced with mozjpeg

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -141,7 +141,7 @@ function javascript() {
 function images() {
   return gulp.src('src/assets/img/**/*')
     .pipe($.if(PRODUCTION, $.imagemin([
-      $.imagemin.jpegtran({ progressive: true }),
+      $.imagemin.mozjpeg({ progressive: true }),
     ])))
     .pipe(gulp.dest(PATHS.dist + '/assets/img'));
 }


### PR DESCRIPTION
jpegtran is no longer available. mozjpeg is the replacement. This fixes the errors when opening a new project after the command `$ foundation watch`

https://github.com/foundation/foundation-sites/issues/12113 < sorry, this was the wrong place to drop the issue, but here is more information if needed!